### PR TITLE
Add support for section annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The goal is not to have a holistic representation of the full TeXoo model but ra
 | Annotation            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | MentionAnnotation     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | NamedEntityAnnotation | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| SectionAnnotation     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+
 
 :broken_heart: = Implemented but untested
 

--- a/texoopy/model/Annotation.py
+++ b/texoopy/model/Annotation.py
@@ -17,10 +17,13 @@ class Annotation(Span):
         json_data = copy.deepcopy(json_data)
         from texoopy.model.MentionAnnotation import MentionAnnotation
         from texoopy.model.NamedEntityAnnotation import NamedEntityAnnotation
+        from texoopy.model.SectionAnnotation import SectionAnnotation
         if json_data['class'] == 'MentionAnnotation':
             return MentionAnnotation.from_json(json_data)
         elif json_data['class'] == 'NamedEntityAnnotation':
             return NamedEntityAnnotation.from_json(json_data)
+        elif json_data['class'] == 'SectionAnnotation':
+            return SectionAnnotation.from_json(json_data)
         else:
             raise (Exception("Annotation type not supported!"))
 

--- a/texoopy/model/SectionAnnotation.py
+++ b/texoopy/model/SectionAnnotation.py
@@ -1,0 +1,28 @@
+import copy
+import json
+
+from .Annotation import Annotation
+
+
+class SectionAnnotation(Annotation):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.sectionHeading: str = kwargs.get('sectionHeading')
+        self.sectionLabel: str = kwargs.get('sectionLabel')
+        self.label: str = kwargs.get('label')
+
+    @classmethod
+    def from_json(cls, json_data: dict):
+        json_data = copy.deepcopy(json_data)
+        return cls(**json_data)
+
+    def to_json(self):
+        return json.dumps(self.to_texoo_dict(), default=lambda o: o.to_texoo_dict())
+
+    def to_texoo_dict(self) -> dict:
+        content = super().to_texoo_dict()
+        content['class'] = 'SectionAnnotation'
+        if content['text'] is None:
+            content = dict(content)
+            del content['text']
+        return content

--- a/texoopy/tests/res/pubmedsection_example.json
+++ b/texoopy/tests/res/pubmedsection_example.json
@@ -1,0 +1,114 @@
+{
+  "id" : "21189927",
+  "title" : "Reemergence of mumps",
+  "language" : "en",
+  "begin" : 0,
+  "length" : 14284,
+  "text" : "The mumps virus is a single-stranded, non-segmented, negative-sense RNA virus belonging to the family. Mumps is characterized by bilateral or unilateral swelling of the parotid gland. Aseptic meningitis is a common complication, and orchitis is also common in adolescents and adult men. Diagnosis is based on clinical findings, but because of high vaccination coverage, clinical findings alone are not sufficient for diagnosis, and laboratory confirmation is needed. Mumps is preventable by vaccination, but despite high vaccination coverage, epidemics occur in several countries, including Korea. Many hypotheses are suggested for these phenomena. In this review, we investigate the reason for the epidemics, optimal methods of diagnosis, and surveillance of immunization status for the prevention of future epidemics. The history of mumps dates back to the 5th century B.C., when Hippocrates described it as \"bilateral or unilateral swelling near the ears, and some of them had bilateral or unilateral pain and swelling of the testicles.\". However, isolation and culture of the virus was only possible in 1945, and vaccination was first licensed in 1967. Without routine immunization, the incidence is estimated to be 100-1,000 cases per million, with an epidemic every 4-5 years. However, universal vaccination has contributed greatly to the decline in the incidence of mumps worldwide. Finland was the first country to declare itself mumps-free in 2000 after a national 2-dose MMR vaccination program for children, resulting in high vaccination coverage The clinical diagnosis of mumps is not difficult in population with low vaccination coverage, but currently because of high vaccine coverage and low incidence of mumps, clinical diagnosis of mumps is complicated. Major outbreaks have occurred worldwide, despite the high rate of vaccination coverage The mumps virus is a single-stranded, non-segmented, negative-sense RNA virus that belongs to the Paramyxoviridae family along with parainfluenza virus, measles virus, respiratory syncytial virus, and human metapneumovirus. It is composed of 7 major proteins, and the major antigens are glycoproteins V antigen and F protein, and a nucleocapsid protein S antigen. It is subdivided into 12 genotypes according to the hydrophobic membrane-associated protein (SH), and the B, F, and I genotypes are common in Asia. The cross-neutralization capacity of the genotypes is known to have decreased but this alone does not explain the increase in vaccine failure Prior to vaccination, mumps was an epidemic disease, with a cycle of 4-5 years. It was predominant in the pediatric population, with seasonal outbreaks in winter and spring. It had been reported that by adolescence, 90% of the population demonstrated serologic evidence of infection Sporadic outbreaks have been reported in several countries, including Belarus, the United States, Canada, the United Kingdom, Israel, Moldova, and Netherlands The recent mumps outbreaks in the United Kingdom in 2005 An outbreak in the United States was reported in 2006; over 5,800 cases were reported. Most cases were in college students aged 18-24 years and the majority had been vaccinated twice The outbreaks are believed to be caused by multiple factors: inadequate levels of vaccination, primary or secondary vaccine failure, antigenic differences between the outbreak and vaccine strains, increased risk of transmission associated with college campuses, inherent limitations in mumps protective immunity, and misdiagnosis of infection. Some of the following clinical features may be found in cases of mumps. 1. Short course with non-specific signs and symptoms 2. Full-blown case with swelling of salivary glands without but no complications 3. Severe mumps and complications 4. No apparent symptoms but typical antibody responses 5. Meningoencephalitis or orchitis but no involvement of the salivary glands Approximately 75% of all cases of apparent mumps in children are full-blown but without complications. Up to 30% of children infected with mumps may not even show signs of parotitis. Parotid gland swelling is at its maximum at 1-3 days and gradually decreases by 7 days. Generally, the clinical manifestations appear to be mild in children and severe in adults. Complications are less common after vaccination. Except for the cases with complications, a typical mumps infection follows the course of fever, anorexia, headache, vomiting, and generalized aches and pains during the prodromal periods of days 1 and 2. Then, the parotid gland begins to enlarge and the enlargement is accompanied by slight redness of the orifices of the Stensen or Wharton ducts; 70-80% of cases show bilateral involvement. Aseptic meningitis is the most common complication in children. Meningeal irritation signs are more prevalent in older children, adolescents, and adults, and nonspecific findings such as drowsiness and lethargy prevail in younger children. Further, 50-60% of patients have pleocytosis in the cerebrospinal fluid (CSF) but only one-sixth of these patients have meningeal symptoms. Encephalitis develops in approximately 0.5% cases, and mumps meningoencephalitis is known to have better prognosis than other viral meningoencephalitis. Epididymo-orchitis and oophoritis does not occur if the infection occurs prior to adolescence. They are the most common clinical manifestations after parotitis in adolescent boys and adult men, usually in those aged 15-29 years. In 80% of all mumps orchitis cases, symptoms are first observed during the first 8 days of involvement of the salivary gland, usually unilateral involvement, with 15-30% of cases showing bilateral involvement Pancreatitis occurs in 3% of cases Viruria is common in uncomplicated mumps cases and is accompanied by mild abnormalities in renal function Deafness occurs in 0.5-5.0/100,00 cases of mumps Prior to the development of the vaccine, the incidence of mumps during pregnancy was 0.8-1.0 cases per 10,000 pregnancies Other less frequent manifestations are exanthem and enanthem, arthritis, myocarditis, thrombocytopenia, keratouveitus, lower respiratory tract infection, and other glandular involvement (thyroiditis, mastitis, dacryoadenitis, and bartholinitis). The virus replicates within the upper respiratory tract and is transmitted through contaminated respiratory droplets or saliva and fomites. The virus is isolated 7 days before and 9 days after parotid gland swelling, with the greatest transmission during the 7-day period beginning 2 days before the onset of parotitis. Asymptomatic patients may also shed the virus. The incubation period spans from 12 days up to a maximum of 25 days and is usually known to be 16-18 days. Since the infectivity of mumps is lower than that of measles, a significant number of persons pass through childhood without being infected with the mumps virus. Primary viral replication occurs in the upper respiratory mucosal epithelium. Then, the virus drains to the local lymph nodes. After that, viremia occurs, and the virus spread to multiple secondary infection sites, including the salivary glands, inner ear, pancreas, heart, nervous system, joints, kidneys, liver, gonads, and thyroid. In response to viral infection, humoral and cellular immune responses are activated. The humoral immune response is induced by the production of serum antibodies to the V, F, and S antigens. The antibody to the S antigen persists for 3-7 days after the onset of symptoms and is short-lived; it is usually absent after 6 months. The antibody to the V antigen is noted for 2-4 weeks after the onset of illness and persists for long periods after infection. IgM is present early in the course of infection and is usually undetectable for 3 months after the onset of illness. IgG is detected at the end of the first week of illness; it peaks 3 weeks later and persists throughout life, mainly as IgG1. Salivary IgA is produced as well. Reinfection is common and patients with a history of mumps show antibody response patterns suggestive of reinfection and not primary infection. Specifically, the IgG but not IgM titer rises in these patients. The cellular immune response is also induced. In a study by Gans et al According to the Centers for Disease Control and Prevention (CDC), a clinical case of mumps is defined as acute onset of unilateral or bilateral tender, self-limited swelling of the parotid or other salivary glands that lasts for ≥2 days and occurs in the absence of other apparent causes. Confirmed cases are either laboratory confirmed or meet the clinical case definition and are epidemiologically linked to a confirmed or probable case. Probable cases meet the clinical case definition but are neither laboratory-confirmed nor epidemiologically linked to another confirmed or probable case. During epidemics, diagnosis may be made on the basis of history of exposure, incubation period of 2-3 weeks, and typical clinical manifestations of fever and parotitis. However, in sporadic cases or cases of mumps in a previously vaccinated child, laboratory findings such as virus isolation, virus detection, elevation of antibody titer, and serum amylase levels are needed to make a diagnosis. These criteria apply especially to cases occurring in areas with high vaccination rates. Virus isolation is performed using the saliva, CSF, or seminal fluid collected within the first week of manifestation of symptoms. Virus isolation from blood is only possible during the first 3 days of illness. Cell culture, RT-PCR, and quantitative real time RT-PCR are used to detect the mumps virus. Culture as the sole method of diagnosis is not recommended since the cytopathic effect may not be evident in some strains of the mumps virus, and cellular pathologic changes may also be observed in other diseases that need to be differentiated from mumps. RT-PCR is more sensitive than cell culture-based methods, and quantitative real time RT-PCR may be needed to quantify the viral burden. Serologic testing may be used to detect IgM, and this method is optimal for 7-10 days after symptoms develop. However, this method should be used with caution since those with a history of mumps or those who have been vaccinated may not demonstrate a rise in IgM levels. IgM is not detected after 3 months. IgG is first detected 1 week after symptoms manifest, and its titer peaks at 3 weeks after initial symptoms. However, vaccination may prevent such peaks and hence should not be used to exclude the diagnosis of mumps. Serologic testing is only informative for mumps diagnosis and is of limited predictive value for assessing protecting immunity. The mumps virus is not the only cause of parotitis. Parotitis may be caused by EBV, coxsackieviruses, echoviruses, influenza A virus, parainfluenza viruses, CMV, HHV-6, etc. Bacterial parotitis is characterized by exquisite tenderness of the region, elevated WBC count, and pus draining from the Stensen duct. Lymph node enlargement is also an important differential diagnosis. Clinical findings need to be supplemented with laboratory evidence for the diagnosis of mumps, but only 10% of clinically diagnosed mumps could be confirmed with laboratory tests There is no specific treatment for mumps. Symptomatic treatment such as hydration and alimentation of patients is important, and analgesics may be used to treat the severe headaches or discomfort caused by parotitis. Antiviral agents are inappropriate and not indicated. Supportive treatment should be provided in cases with mumps orchitis. Steroid administration to patients with mumps orchitis is not recommended because steroids may further lower the level of testosterone and increase the level of FSH and LH, further aggravating atrophy of the testes Symptomatic treatment aids greatly in recovery in most cases. Meningoencephalitis has a generally favorable outcome, although neurological damage and death can occur. Deafness and sterility are rare complications. Mumps can be prevented by the measles, mumps, rubella (MMR) vaccine. The MMR vaccine is widely used worldwide (in 114 nations) since being licensed in 1967. The first dose is given at 12-15 months of age, and the timing of the second dose differs among countries. Vaccination of 90% of the population is believed to provide herd immunity against the mumps virus Viral strains used in the vaccines include Jeryl-Lynn, RIT 4385, Urabe Am9, Leningrad-3, and Leningrad-Zagreb strains. There are 2 types of vaccines currently marketed in Korea. One is Priorix® from GSK; it uses the RIT 4385 strain. The other is MMR® II from Merck; it uses the Jeryl-Lynn strain. The Rubini strain was abandoned in routine vaccination programs by the WHO because of its low efficacy Further, 95% efficacy was reported with the Jeryl-Lynn strain in randomized clinical trials Post-exposure vaccination is not effective for mumps, although vaccination is needed to prevent further infections, and the risk does not increase even if vaccination is performed during the incubation period. We cannot predict who will get mumps during an outbreak. No serologic test reliably predicts who is at risk and who is not It is important to consider that individuals possessing low antibody titers or even those lacking measurable antibody titers might not necessarily be susceptible to symptomatic mumps virus infection because they might be fully protected by cell mediated immunity. Cell-mediated immunity has been observed in seronegative vaccine recipients even 21 years after vaccination Despite the high coverage of immunization, mumps outbreaks are reported. Various factors are considered to explain this observation, such as primary or secondary vaccine failure, inadequate levels of vaccination, antigenic differences between the outbreak and vaccine strains, increased risk of transmission associated with college campuses, inherent limitations in mumps protective immunity, and misdiagnosis. To prevent major outbreaks, further investigations are needed to identify the optimal method of diagnosis, monitor immunization status, and establish the most efficient vaccination schedule. However, as observed in the Finland outbreak, maintaining a high vaccination rate is the most important step toward preventing a mumps outbreak.",
+  "annotations" : [ {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 0,
+    "length" : 818,
+    "sectionHeading" : "Abstract",
+    "sectionLabel" : "disease.other",
+    "label" : "disease.other",
+    "confidence" : 1.0
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 819,
+    "length" : 1036,
+    "sectionHeading" : "Introduction",
+    "sectionLabel" : "disease.symptom",
+    "label" : "disease.symptom"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 1857,
+    "length" : 653,
+    "sectionHeading" : "Virology",
+    "sectionLabel" : "disease.other",
+    "label" : "disease.other"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 2511,
+    "length" : 1021,
+    "sectionHeading" : "Epidemiology",
+    "sectionLabel" : "disease.epidemiology",
+    "label" : "disease.epidemiology"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 3537,
+    "length" : 2689,
+    "sectionHeading" : "Clinical manifestations",
+    "sectionLabel" : "disease.symptom",
+    "label" : "disease.symptom"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 6241,
+    "length" : 635,
+    "sectionHeading" : "Transmission",
+    "sectionLabel" : "disease.infection",
+    "label" : "disease.infection"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 6877,
+    "length" : 1345,
+    "sectionHeading" : "Pathogenesis and pathology",
+    "sectionLabel" : "disease.mechanism",
+    "label" : "disease.mechanism"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 8224,
+    "length" : 2424,
+    "sectionHeading" : "Diagnosis",
+    "sectionLabel" : "disease.diagnosis",
+    "label" : "disease.diagnosis"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 10651,
+    "length" : 556,
+    "sectionHeading" : "Differential diagnosis",
+    "sectionLabel" : "disease.diagnosis",
+    "label" : "disease.diagnosis"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 11208,
+    "length" : 555,
+    "sectionHeading" : "Treatment",
+    "sectionLabel" : "disease.treatment",
+    "label" : "disease.treatment"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 11764,
+    "length" : 213,
+    "sectionHeading" : "Prognosis",
+    "sectionLabel" : "disease.prognosis",
+    "label" : "disease.prognosis"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 11978,
+    "length" : 1553,
+    "sectionHeading" : "Immunization",
+    "sectionLabel" : "disease.prevention",
+    "label" : "disease.prevention"
+  }, {
+    "class" : "SectionAnnotation",
+    "source" : "GOLD",
+    "begin" : 13537,
+    "length" : 746,
+    "sectionHeading" : "Conclusion",
+    "sectionLabel" : "disease.other",
+    "label" : "disease.other"
+  } ]
+}

--- a/texoopy/tests/tests.py
+++ b/texoopy/tests/tests.py
@@ -3,6 +3,7 @@ import json
 import os
 import unittest
 
+from ..model.SectionAnnotation import SectionAnnotation
 from ..model.Annotation import Annotation
 from ..model.Document import Document, NotATeXooDocumentException
 from ..model.MentionAnnotation import MentionAnnotation
@@ -11,6 +12,7 @@ from ..model.Span import Span
 from ..model.Dataset import Dataset
 
 TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'res', 'texoo_dataset.json')
+SECTION_ANNOTATION_TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'res', 'pubmedsection_example.json')
 
 
 class DatasetTest(unittest.TestCase):
@@ -168,6 +170,38 @@ class NamedEntityAnnotationTest(unittest.TestCase):
         self.assertEqual(self.named_entity_ann_json_dict, json.loads(self.named_entity_ann.to_json()))
 
     def test_named_ann_toJson_mutability(self):
+        pass  # TODO IMPLEMENT ME
+
+
+class SectionAnnotationTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        with open(SECTION_ANNOTATION_TESTDATA_FILENAME, 'r') as test_file:
+            self.section_ann_json_dict = json.load(test_file)['annotations'][0]
+            self.section_ann = Annotation.from_json(self.section_ann_json_dict)
+
+    def test_section_ann_class(self):
+        self.assertIsInstance(self.section_ann, SectionAnnotation)
+
+    def test_section_ann_begin(self):
+        self.assertEqual(0, self.section_ann.begin)
+
+    def test_section_ann_length(self):
+        self.assertEqual(818, self.section_ann.length)
+
+    def test_section_ann_text(self):
+        self.assertIsNone(None, self.section_ann.text)
+
+    def test_section_ann_source(self):
+        self.assertEqual("GOLD", self.section_ann.source)
+
+    def test_section_ann_confidence(self):
+        self.assertEqual(1.0, self.section_ann.confidence)
+
+    def test_section_ann_to_json(self):
+        self.assertEqual(self.section_ann_json_dict, json.loads(self.section_ann.to_json()))
+
+    def test_section_ann_toJson_mutability(self):
         pass  # TODO IMPLEMENT ME
 
 


### PR DESCRIPTION
This PR adds support for [SecitonAnnotations](https://github.com/sebastianarnold/TeXoo/blob/master/texoo-sector/src/main/java/de/datexis/sector/model/SectionAnnotation.java) that are produced by models like SECTOR and CDV. Additionally, it adds a document from the [PubMemSection dataset](https://pubmedsection.demo.datexis.com/) as a test resource. 